### PR TITLE
Error on = or :: used as binding-pattern id

### DIFF
--- a/bitsyntax/bitmatch.rkt
+++ b/bitsyntax/bitmatch.rkt
@@ -125,6 +125,12 @@
      (parse-trailer (syntax discard) (syntax (:: trailer ...))))
     ((id trailer ...)
      (parse-trailer (syntax (bind id)) (syntax (trailer ...))))
+    (::
+     (raise-syntax-error 'bit-string-case
+                         "\"::\" cannot be used as binding-pattern id"))
+    (=
+     (raise-syntax-error 'bit-string-case
+                         "\"=\" used outside of comparison-pattern"))
     (id
      (parse-trailer (syntax (bind id)) (syntax ())))))
 

--- a/bitsyntax/test-bitmatch-bitstitch.rkt
+++ b/bitsyntax/test-bitmatch-bitstitch.rkt
@@ -3,7 +3,8 @@
 (require "bitstring.rkt")
 (require "bitmatch.rkt")
 (require "bitstitch.rkt")
-(require rackunit)
+(require rackunit
+         syntax/macro-testing)
 
 (define (experiment-one v)
   (bit-string-case v
@@ -283,3 +284,14 @@
                 ([ (v :: (next-four)) ] (bit-string->bytes v))
                 (else #f))
               'short)
+
+(check-exn #rx"(?i:.*::.*binding-pattern.*)"
+           (lambda () (convert-compile-time-error
+                       (bit-string-case #"\0\0"
+                         ([x ::] x)))))
+
+(check-exn #rx"(?i:.*=.*used outside.*comparison.*)"
+           (lambda () (convert-compile-time-error
+                       (bit-string-case #"\0\0"
+                         ([x =] x)))))
+


### PR DESCRIPTION
This should prevent users from missing segment-pattern parenthesis and accidentally using `=` and `::` as a binding.

This package has saved me a lot of effort, thanks!